### PR TITLE
zap permalink

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,3 +1,2 @@
-permalink: pretty
 plugins:
   - jekyll-sitemap


### PR DESCRIPTION
### no need for permalink option

i did [some research](https://ryanve.github.io/sluj) to discover github pages serve HTML files with and without extension regardless of permalink option


